### PR TITLE
Add weighted scalability and user friction metrics

### DIFF
--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -12,12 +12,16 @@ from sabre_metrics import (
     calculate_ats,
     calculate_tcs,
     calculate_rtv,
+    calculate_wsps,
+    calculate_wufs,
 )
 
 ats = calculate_ats([10, 12, 8], [2, 1, 3], [1, 2, 1])
 tcs = calculate_tcs(15, 10, 5, 2)
 rtv = calculate_rtv(ats, tcs)
-print(ats, tcs, rtv)
+wsps = calculate_wsps(50, 40, 2.0, 3.0)
+wufs = calculate_wufs(4, 1, 120000, 5)
+print(ats, tcs, rtv, wsps, wufs)
 ```
 
 For more details on each metric see the documents in this `docs/` directory.

--- a/docs/weighted_vs_group/WSPS.md
+++ b/docs/weighted_vs_group/WSPS.md
@@ -1,0 +1,14 @@
+# Weighted Scalability Performance Score (WSPS)
+
+This metric places a stronger emphasis on resolution efficiency while still
+accounting for ticket volume. It uses a non-linear weighting of each factor.
+
+## Formula
+
+```
+WSPS = (Agent_Tickets / Team_Avg_Tickets)^0.7 *
+       (Team_Avg_Resolution_Time / Agent_Resolution_Time)^1.3
+```
+
+Higher scores indicate an agent can handle increased workload without slowing
+down.

--- a/docs/weighted_vs_group/WUFS.md
+++ b/docs/weighted_vs_group/WUFS.md
@@ -1,0 +1,14 @@
+# Weighted User Friction Score (WUFS)
+
+A time-weighted variant of the standard User Friction Score. Replies and
+reassignments are converted into estimated minutes and combined with the total
+time a ticket remains open.
+
+## Formula
+
+```
+WUFS = (Reply_Count * 2 + Reassign_Count * 5 + Time_Open_ms / 60000) /
+       Ticket_Count
+```
+
+The score represents the average user minutes lost per ticket.

--- a/examples/calculate_metrics.py
+++ b/examples/calculate_metrics.py
@@ -1,4 +1,6 @@
 import argparse
+from sabre_metrics.weighted_scalability_performance_score import calculate_wsps
+from sabre_metrics.weighted_user_friction_score import calculate_wufs
 
 
 def calculate_ats(resolution, response, first_response):
@@ -18,13 +20,12 @@ def calculate_rtv(ats, tcs):
 
 def calculate_weighted_sps(agent_tickets, team_avg_tickets, agent_res_time, team_res_time):
     """Compute Weighted Scalability Performance Score."""
-    return (agent_tickets / team_avg_tickets) ** 0.7 * (team_res_time / agent_res_time) ** 1.3
+    return calculate_wsps(agent_tickets, team_avg_tickets, agent_res_time, team_res_time)
 
 
 def calculate_weighted_ufs(reply_count, reassign_count, time_ms, ticket_count):
     """Compute time-weighted User Friction Score in minutes."""
-    total_minutes = reply_count * 2 + reassign_count * 5 + time_ms / 60000
-    return total_minutes / ticket_count
+    return calculate_wufs(reply_count, reassign_count, time_ms, ticket_count)
 
 
 def calculate_tri(medium_loss, high_loss, urgent_loss, violations):

--- a/src/sabre_metrics/__init__.py
+++ b/src/sabre_metrics/__init__.py
@@ -5,6 +5,8 @@ from .ticket_complexity_score import calculate_tcs
 from .real_technician_value import calculate_rtv
 from .scalability_performance_score import calculate_sps
 from .user_friction_score import calculate_ufs
+from .weighted_scalability_performance_score import calculate_wsps
+from .weighted_user_friction_score import calculate_wufs
 from .total_revenue_impact import calculate_tri
 from .weighted_ticket_complexity_score import calculate_wtcs
 from .weighted_real_technician_value import calculate_wrtv
@@ -15,6 +17,8 @@ __all__ = [
     "calculate_rtv",
     "calculate_sps",
     "calculate_ufs",
+    "calculate_wsps",
+    "calculate_wufs",
     "calculate_tri",
     "calculate_wtcs",
     "calculate_wrtv",

--- a/src/sabre_metrics/weighted_scalability_performance_score.py
+++ b/src/sabre_metrics/weighted_scalability_performance_score.py
@@ -1,0 +1,18 @@
+"""Weighted Scalability Performance Score utilities."""
+
+from __future__ import annotations
+
+def calculate_wsps(
+    agent_tickets: float,
+    team_avg_tickets: float,
+    agent_resolution_time: float,
+    team_avg_resolution_time: float,
+) -> float:
+    """Calculate Weighted Scalability Performance Score (WSPS)."""
+    if team_avg_tickets <= 0 or agent_resolution_time <= 0:
+        raise ValueError("Inputs would lead to division by zero")
+
+    return (
+        (agent_tickets / team_avg_tickets) ** 0.7
+        * (team_avg_resolution_time / agent_resolution_time) ** 1.3
+    )

--- a/src/sabre_metrics/weighted_user_friction_score.py
+++ b/src/sabre_metrics/weighted_user_friction_score.py
@@ -1,0 +1,16 @@
+"""Weighted User Friction Score utilities."""
+
+from __future__ import annotations
+
+def calculate_wufs(
+    reply_count: int,
+    reassign_count: int,
+    time_ms: float,
+    ticket_count: int,
+) -> float:
+    """Calculate time-weighted User Friction Score in minutes per ticket."""
+    if ticket_count <= 0:
+        raise ValueError("ticket_count must be greater than zero")
+
+    total_minutes = reply_count * 2 + reassign_count * 5 + time_ms / 60000
+    return total_minutes / ticket_count

--- a/tests/test_weighted_scalability_performance_score.py
+++ b/tests/test_weighted_scalability_performance_score.py
@@ -1,0 +1,15 @@
+import pytest
+from sabre_metrics.weighted_scalability_performance_score import calculate_wsps
+
+
+def test_calculate_wsps_basic():
+    score = calculate_wsps(50, 40, 2.0, 3.0)
+    expected = (50 / 40) ** 0.7 * (3.0 / 2.0) ** 1.3
+    assert score == pytest.approx(expected)
+
+
+def test_wsps_zero_division():
+    with pytest.raises(ValueError):
+        calculate_wsps(10, 0, 1, 1)
+    with pytest.raises(ValueError):
+        calculate_wsps(10, 5, 0, 1)

--- a/tests/test_weighted_user_friction_score.py
+++ b/tests/test_weighted_user_friction_score.py
@@ -1,0 +1,13 @@
+import pytest
+from sabre_metrics.weighted_user_friction_score import calculate_wufs
+
+
+def test_calculate_wufs_basic():
+    score = calculate_wufs(4, 1, 120000, 5)
+    expected = (4 * 2 + 1 * 5 + 120000 / 60000) / 5
+    assert score == pytest.approx(expected)
+
+
+def test_wufs_zero_tickets():
+    with pytest.raises(ValueError):
+        calculate_wufs(1, 1, 1000, 0)


### PR DESCRIPTION
## Summary
- implement `calculate_wsps` and `calculate_wufs`
- expose new utilities in package init
- document WSPS and WUFS formulas
- update quickstart guide and examples
- add unit tests for weighted metrics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848f366d66083208e0b833e033ed98a