### PR TITLE
Fix WTCS formula in CLI example

### DIFF
--- a/examples/calculate_metrics.py
+++ b/examples/calculate_metrics.py
@@ -35,8 +35,13 @@ def calculate_tri(medium_loss, high_loss, urgent_loss, violations):
 
 def calculate_wtcs(low, medium, high, urgent, stddev):
     """Weighted Ticket Complexity Score."""
-    base = calculate_tcs(low, medium, high, urgent)
-    return base * (stddev / 0.2)
+    weighted_total = (
+        (low * 0.1)
+        + (medium * 0.2)
+        + (high * 0.3)
+        + (urgent * 0.4)
+    )
+    return weighted_total * stddev
 
 
 def calculate_wrtv(ats, low, medium, high, urgent):


### PR DESCRIPTION
## Summary
- adjust calculate_wtcs in `examples/calculate_metrics.py` to match the library implementation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684993b5b89c8320a918b9c4e2fe55ac