### PR TITLE
Clarify WTCS scaling in docs

### DIFF
--- a/docs/weighted_vs_group/WTCS.md
+++ b/docs/weighted_vs_group/WTCS.md
@@ -24,8 +24,7 @@ Tickets are categorized into four tiers based on priority:
 
 Add the standard deviation across the last 90 days (calculated separately). We'll denote this as **D** (1.788 in the example).
 
-Multiply by `0.1` to keep scores easy to read.
-
+Optionally, you can apply a small scaling factor (e.g., 0.1) for readability, but the standard implementation multiplies the weighted sum directly by D.
 ### 2.) WTCS Formula
 ```
 WTCS = Σ(Tickets Resolved × Complexity Weight) × D


### PR DESCRIPTION
## Summary
- clarify that scaling with a constant like `0.1` is optional
- fix missing newline in WTCS docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684993b640048320953552ca33762998